### PR TITLE
Meilleur gestion du scroll vers les sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   </head>
 
   <body ng-app="breizhjugApp" id="ng-app">
-    <header class="navbar navbar-fixed-top">
+    <header class="navbar navbar-fixed-top" ng-controller="menuController">
       <div class="navbar-inner">
         <div class="grid">
           <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
@@ -26,18 +26,17 @@
             <span class="icon-bar"></span>
           </a>
 
-          <a class="brand" href="#/home/"><img src="images/logo-txt.png"></a>
+          <a class="brand" href ng-click="homeSectionClick('head')"><img src="images/logo-txt.png"></a>
 
           <div class="nav-collapse collapse">
             <ul class="nav">
               <li class="dropdown">
                 <a href class="dropdown-toggle" data-toggle="dropdown">Home<b class="caret"></b></a>
-                <ul class="dropdown-menu">
-                  <li><a href="#/home/next">événements</a></li>
-                  <li><a href="#/home/speakers">Speakers</a></li>
-                  <li><a href="#/home/news">News</a></li>
-                  <li><a href="#/home/team">Team</a></li>
-                  <li><a href="#/home/sponsors">Partners</a></li>
+                <ul id="menu-popup" class="dropdown-menu">
+                  <li><a href ng-click="homeSectionClick('next')">événements</a></li>
+                  <li><a href ng-click="homeSectionClick('news')">News</a></li>
+                  <li><a href ng-click="homeSectionClick('team')">Team</a></li>
+                  <li><a href ng-click="homeSectionClick('sponsors')">Partners</a></li>
                 </ul>
               </li>
               <li><a href="#/speakers">Speakers</a></li>
@@ -46,7 +45,7 @@
         </div>
       </div>
     </header>
-    <div class="menu-spacer"></div>
+    <div id="menu-spacer"></div>
 
     <!--[if lt IE 8]>
     <p class="chromeframe">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -75,12 +75,12 @@ header .nav li a {
 	font: normal 17px/17px "GothamBook","Helvetica Neue", Arial, Helvetica, Geneva, sans-serif;
 }
 
-.menu-spacer {
+#menu-spacer {
     height: 53px;
 }
 
 @media (max-width: 979px) {
-    .menu-spacer {
+    #menu-spacer {
         height: 0;
     }
     .navbar-fixed-top {
@@ -111,7 +111,7 @@ header .nav li a {
 	color: #fff;
 }
 .lightgrey {
-	background: #f0ebe4 url(../images/lightgrey_bg.jpg);
+	background: #f0ebe4;
 }
 .black {
 	background: #000;
@@ -211,40 +211,6 @@ h2 {
 }
 #events img {
 	width:250px;
-}
-
-/*########### Home - Speakers ###########*/
-#speakers {
-	background:  #ff6a00 url(../images/lensflare.png) no-repeat center top;
-}
-
-.home-speaker {
-    text-align: center;
-}
-
-.home-speaker-avatar {
-    border: solid 1px #000;
-	height: 160px;
-	width: 160px;
-	line-height: 150px;
-	margin: 1px auto;
-	-webkit-border-radius: 80px;
-	border-radius: 80px;
-}
-
-.home-speaker h4 {
-	color: #fff;
-	text-align: center;
-}
-
-.home-speaker-bio {
- 	border: solid 1px #000;
-	border-radius: 10px;
- 	padding: 5px;
-    background: #fff;
-    box-shadow: 2px 2px 2px #000;
-    text-align: justify;
-    margin: 0 20px 20px 20px;
 }
 
 /*########### Home - News ###########*/


### PR DESCRIPTION
Le précédent hack faisait bugger l'historique, on ne pouvait plus revenir en arrière avec le bouton précédent. L'url n'était pas très propre non plus.

Les liens du menu ne sont désormais plus des liens et sont gérés au niveau d'un menuController. Si l'on est sur la page home, on scroll tout simplement vers la section. Sinon on positionne le nom de la section dans le $rootScope, redirige vers la page home et le homeController scroll vers la section.

J'ai aussi supprimé les parties de code qui restait autour de la section speakers (css, controller).
